### PR TITLE
Properly handle exceptions

### DIFF
--- a/src/Cardano/Config/Git/RevFromGit.hs
+++ b/src/Cardano/Config/Git/RevFromGit.hs
@@ -6,7 +6,8 @@ import           Cardano.Prelude
 import           Prelude (String)
 
 import qualified Language.Haskell.TH as TH
-import           System.IO.Error (ioeGetErrorType, isDoesNotExistErrorType)
+import qualified System.IO as IO
+import           System.IO.Error (isDoesNotExistError)
 import           System.Process (readProcessWithExitCode)
 
 -- | Git revision found by running git rev-parse. If git could not be
@@ -15,11 +16,18 @@ gitRevFromGit :: TH.Q TH.Exp
 gitRevFromGit = TH.LitE . TH.StringL <$> TH.runIO runGitRevParse
     where
         runGitRevParse :: IO String
-        runGitRevParse = handleJust missingGit (const $ pure "") $ do
-            (exitCode, output, _) <-
-                readProcessWithExitCode "git" ["rev-parse", "--verify", "HEAD"] ""
-            pure $ case exitCode of
-                ExitSuccess -> output
-                _           -> ""
+        runGitRevParse = do
+            (exitCode, output, errorMessage) <- readProcessWithExitCode_ "git" ["rev-parse", "--verify", "HEAD"] ""
+            case exitCode of
+                ExitSuccess -> pure output
+                ExitFailure _ -> do
+                    IO.hPutStrLn IO.stderr $ "WARNING: " ++ errorMessage
+                    pure ""
 
-        missingGit e = if isDoesNotExistErrorType (ioeGetErrorType e) then Just () else Nothing
+        readProcessWithExitCode_ :: FilePath -> [String] -> String -> IO (ExitCode, String, String)
+        readProcessWithExitCode_ cmd args input =
+            catch (readProcessWithExitCode cmd args input) $ \e ->
+                if isDoesNotExistError e
+                    then return (ExitFailure 127, "", show e)
+                    else return (ExitFailure 999, "", show e)
+


### PR DESCRIPTION
This is to prevent the build from failing if `git` is missing as it did previously.

For example:

```
git: readCreateProcessWithExitCode: posix_spawnp: failed (Undefined error: 0)
```